### PR TITLE
Immich: migration VectorChord + fix morphos

### DIFF
--- a/kubernetes/apps/immich/postgresql-immich.yaml
+++ b/kubernetes/apps/immich/postgresql-immich.yaml
@@ -5,13 +5,14 @@ metadata:
   namespace: immich
 spec:
   instances: 1
-  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16.3-v0.2.1
+  # VectorChord (successor of pgvecto.rs, required by immich >= 3.0)
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.14-1.1.1
   enableSuperuserAccess: true
   primaryUpdateStrategy: unsupervised
   primaryUpdateMethod: restart ##@@ Cannot use switchover with 1 instance
   postgresql:
     shared_preload_libraries:
-      - "vectors.so"
+      - "vchord.so"
     enableAlterSystem: true
   bootstrap:
     initdb:
@@ -21,16 +22,10 @@ spec:
         name: immich-db-secret
       dataChecksums: true
       postInitApplicationSQL:
-        - ALTER SYSTEM SET search_path TO "$user", public, vectors;
-        - SET search_path TO "$user", public, vectors;
-        - CREATE EXTENSION IF NOT EXISTS "vectors";
+        - CREATE EXTENSION IF NOT EXISTS "vchord" CASCADE;
         - CREATE EXTENSION IF NOT EXISTS "cube";
         - CREATE EXTENSION IF NOT EXISTS "earthdistance";
-        - ALTER SCHEMA vectors OWNER TO "immich";
-        - GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA vectors TO "immich";
         - GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO "immich";
-        # - CREATE EXTENSION IF NOT EXISTS "vector";
-        # - ALTER ROLE "immich" WITH "superuser";
 
   storage:
     size: 10Gi

--- a/kubernetes/apps/morphos/deployment.yaml
+++ b/kubernetes/apps/morphos/deployment.yaml
@@ -50,6 +50,10 @@ spec:
           failureThreshold: 3
         securityContext:
           runAsNonRoot: true
+          # image USER is the name "morphos" (uid 1000): kubelet needs a numeric
+          # uid to verify runAsNonRoot, otherwise CreateContainerConfigError
+          runAsUser: 1000
+          runAsGroup: 1000
           allowPrivilegeEscalation: false
           capabilities:
             drop:


### PR DESCRIPTION
Prerequis immich v3. SQL de preparation deja execute. Image CNPG pgvecto.rs -> cloudnative-vectorchord:16.14-1.1.1 (multi-arch).