### PR TITLE
feat(renovate): track Talos and Kubernetes versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,5 +27,18 @@
       "/(^|/)talos/.+\\.ya?ml$/",
       "/(^|/)kubernetes/.+\\.ya?ml$/"
     ]
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track Talos and Kubernetes versions in talconfig.yaml",
+      "managerFilePatterns": [
+        "/(^|/)talos/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+versioning=(?<versioning>\\S+))?\\s*\\n[^:\\n]+:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}docker{{/if}}"
+    }
+  ]
 }

--- a/talos/dorado/talconfig.yaml
+++ b/talos/dorado/talconfig.yaml
@@ -5,7 +5,9 @@ clusterName: &cluster dorado
 endpoint: https://10.243.2.55:6443
 allowSchedulingOnMasters: true
 
+# renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: "v1.13.3"
+# renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: "v1.36.1"
 
 clusterPodNets:


### PR DESCRIPTION
## Objectif

Faire suivre par Renovate les versions **Talos** et **Kubernetes** définies en dur dans `talos/dorado/talconfig.yaml`.

## Changements

- **`talos/dorado/talconfig.yaml`** : annotations `# renovate:` au-dessus de `talosVersion` et `kubernetesVersion`.
- **`.github/renovate.json`** : ajout d'un `customManagers` (regex) qui lit ces annotations dans `talos/**`.

## Sources choisies

| Champ | Datasource | Raison |
|-------|-----------|--------|
| `talosVersion` | `ghcr.io/siderolabs/installer` (docker) | tags = versions Talos |
| `kubernetesVersion` | `ghcr.io/siderolabs/kubelet` (docker) | ne propose que des versions k8s effectivement livrées par Talos |

## Notes

- Renovate ne fait que bumper le fichier — l'application au cluster reste manuelle (`talhelper genconfig` + `talosctl upgrade` / `upgrade-k8s`).
- Cohérent avec la politique « pas d'automerge » : ces PRs seront à valider à la main.
- Validation réelle des tags ghcr au prochain run Renovate (non testable depuis le sandbox local).