### PR TITLE
feat(jellyfin): move cache to RAM

### DIFF
--- a/kubernetes/apps/medias/jellyfin/cache-emptydir-patch.yaml
+++ b/kubernetes/apps/medias/jellyfin/cache-emptydir-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin
+spec:
+  template:
+    spec:
+      volumes:
+        - name: cache
+          emptyDir:
+            medium: Memory
+            sizeLimit: 4Gi

--- a/kubernetes/apps/medias/jellyfin/kustomization.yaml
+++ b/kubernetes/apps/medias/jellyfin/kustomization.yaml
@@ -13,3 +13,9 @@ helmCharts:
     releaseName: jellyfin
     valuesFile: values.yaml
     version: 3.2.0
+
+patches:
+  - path: cache-emptydir-patch.yaml
+    target:
+      kind: Deployment
+      name: jellyfin

--- a/kubernetes/apps/medias/jellyfin/values.yaml
+++ b/kubernetes/apps/medias/jellyfin/values.yaml
@@ -25,7 +25,7 @@ ingress:
 
 resources:
   limits:
-    memory: 6Gi
+    memory: 10Gi
   requests:
     memory: 1Gi
 


### PR DESCRIPTION
## Summary

- move the Jellyfin cache to a memory-backed emptyDir capped at 4Gi
- raise the Jellyfin memory limit from 6Gi to 10Gi while keeping the 1Gi request
- patch the cache volume generated by the Jellyfin Helm chart through Kustomize

## Validation

- rendered the Jellyfin Helm/Kustomize manifests and asserted one RAM-backed cache volume with the expected limits
- validated the medias application with kubeconform: 60 valid resources, 0 invalid, 0 errors